### PR TITLE
#24 core updated + signature calculation fixed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
 	<properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>11</java.version>
-        <self.core.version>0.0.8</self.core.version>
-        <self.storage.version>0.0.3</self.storage.version>
+        <self.core.version>0.0.12</self.core.version>
+        <self.storage.version>0.0.4</self.storage.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/com/selfxdsd/selfpm/Webhooks.java
+++ b/src/main/java/com/selfxdsd/selfpm/Webhooks.java
@@ -32,8 +32,6 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import javax.json.Json;
-import java.io.StringReader;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Formatter;
@@ -69,10 +67,9 @@ public final class Webhooks {
      * @param payload JSON Payload.
      * @return ResponseEntity.
      * @checkstyle ReturnCount (70 lines)
-     * @todo #21:30min We need to modify self-core so that Project
-     *  has the method String :: webHookToken(). Also, method Project.resolve
-     *  should not expect the secret anymore. After that is done, modify
-     *  this method accordingly.
+     * @todo #24:30min Build up the Event based on the payload
+     *  and "event" header (see Github docs) and send it to the
+     *  Project to be resolved (at the moment, null is sent).
      */
     @PostMapping(
         value = "/github/{owner}/{name}",
@@ -90,16 +87,11 @@ public final class Webhooks {
         );
         if (project != null) {
             final String calculated = this.hmacHexDigest(
-                "project_wh_token",
+                project.webHookToken(),
                 payload
             );
             if(calculated != null && calculated.equals(signature)) {
-                project.resolve(
-                    Json.createReader(
-                        new StringReader(payload)
-                    ).readObject(),
-                    signature
-                );
+                project.resolve(null);
             } else {
                 return ResponseEntity.badRequest().build();
             }

--- a/src/test/java/com/selfxdsd/selfpm/WebhooksTestCase.java
+++ b/src/test/java/com/selfxdsd/selfpm/WebhooksTestCase.java
@@ -22,17 +22,12 @@
  */
 package com.selfxdsd.selfpm;
 
-import com.selfxdsd.api.Project;
-import com.selfxdsd.api.Projects;
-import com.selfxdsd.api.Provider;
-import com.selfxdsd.api.Self;
+import com.selfxdsd.api.*;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
-
-import javax.json.JsonObject;
 
 /**
  * Unit tests for {@link Webhooks}.
@@ -69,9 +64,10 @@ public final class WebhooksTestCase {
     @Test
     public void githubProjectBadSignature() {
         final Project project = Mockito.mock(Project.class);
-        Mockito.doThrow(IllegalArgumentException.class)
+        Mockito.when(project.webHookToken()).thenReturn("project_wh_token");
+        Mockito.doThrow(IllegalStateException.class)
             .when(project)
-            .resolve(Mockito.any(JsonObject.class), Mockito.anyString());
+            .resolve(Mockito.any(Event.class));
         final Projects all = Mockito.mock(Projects.class);
         Mockito.when(
             all.getProjectById("john/test", Provider.Names.GITHUB)
@@ -96,9 +92,10 @@ public final class WebhooksTestCase {
     @Test
     public void githubProjectResolvesOk() {
         final Project project = Mockito.mock(Project.class);
+        Mockito.when(project.webHookToken()).thenReturn("project_wh_token");
         Mockito.doNothing()
             .when(project)
-            .resolve(Mockito.any(JsonObject.class), Mockito.anyString());
+            .resolve(Mockito.any(Event.class));
         final Projects all = Mockito.mock(Projects.class);
         Mockito.when(
             all.getProjectById("john/test", Provider.Names.GITHUB)


### PR DESCRIPTION
Fixes #24  (updated core and storage deps)
It also takes care of #23 , the signature calculation logic is now correctly based on Project.webHookToken(). 
Left puzzle to continue work on building the actual Event.