### PR TITLE
#54 Webhook Event Can Be Pull_Request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 	<properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>11</java.version>
-        <self.core.version>0.0.30</self.core.version>
+        <self.core.version>0.0.31</self.core.version>
         <self.storage.version>0.0.14</self.storage.version>
 	</properties>
 

--- a/src/main/java/com/selfxdsd/selfpm/ReviewAssignedTasks.java
+++ b/src/main/java/com/selfxdsd/selfpm/ReviewAssignedTasks.java
@@ -106,6 +106,14 @@ public final class ReviewAssignedTasks {
                         }
 
                         @Override
+                        public Commit commit() {
+                            throw new UnsupportedOperationException(
+                                "No Commit in the " + Type.ASSIGNED_TASKS
+                                + " event."
+                            );
+                        }
+
+                        @Override
                         public Project project() {
                             return project;
                         }

--- a/src/main/java/com/selfxdsd/selfpm/ReviewUnassignedTasks.java
+++ b/src/main/java/com/selfxdsd/selfpm/ReviewUnassignedTasks.java
@@ -106,6 +106,14 @@ public final class ReviewUnassignedTasks {
                         }
 
                         @Override
+                        public Commit commit() {
+                            throw new UnsupportedOperationException(
+                                "No Commit in the " + Type.UNASSIGNED_TASKS
+                                + " event."
+                            );
+                        }
+
+                        @Override
                         public Project project() {
                             return project;
                         }

--- a/src/main/java/com/selfxdsd/selfpm/Webhooks.java
+++ b/src/main/java/com/selfxdsd/selfpm/Webhooks.java
@@ -148,6 +148,11 @@ public final class Webhooks {
                         }
 
                         @Override
+                        public Commit commit() {
+                            return null;
+                        }
+
+                        @Override
                         public Project project() {
                             return project;
                         }

--- a/src/main/java/com/selfxdsd/selfpm/Webhooks.java
+++ b/src/main/java/com/selfxdsd/selfpm/Webhooks.java
@@ -44,6 +44,8 @@ import java.util.Formatter;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.2
+ * @todo #54:30min In the github Webhook, if the event is "push",
+ *  make sure to receive and return the latest Commit from the Event.
  */
 @RestController
 public final class Webhooks {

--- a/src/main/java/com/selfxdsd/selfpm/Webhooks.java
+++ b/src/main/java/com/selfxdsd/selfpm/Webhooks.java
@@ -135,11 +135,15 @@ public final class Webhooks {
 
                         @Override
                         public Issue issue() {
+                            final JsonObject jsn;
+                            if("pull_request".equalsIgnoreCase(type)) {
+                                jsn = this.event.getJsonObject("pull_request");
+                            } else {
+                                jsn = this.event.getJsonObject("issue");
+                            }
                             return project.projectManager().provider().repo(
                                 owner, name
-                            ).issues().received(
-                                this.event.getJsonObject("issue")
-                            );
+                            ).issues().received(jsn);
                         }
 
                         @Override


### PR DESCRIPTION
Fixes #54 
Updated self-core to 0.0.31
Updated Event.issue() in the Webhook endpoint in order to read the ``pull_request`` object if the Event's type is "pull_request".